### PR TITLE
glad2 2.0.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_check: false

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "2.0.8" %}
 
 package:
-  name: glad2
+  name: glad2-split
   version: {{ version }}
 
 source:
@@ -13,10 +13,10 @@ build:
 
 outputs:
   - name: glad2
+    script: python -m pip install . --no-deps --no-build-isolation -vv
     build:
       entry_points:
         - glad = glad.__main__:main
-      script: python -m pip install . --no-deps --no-build-isolation -vv
     requirements:
       host:
         - pip
@@ -26,6 +26,13 @@ outputs:
       run:
         - python
         - jinja2 >=2.7,<4.0
+    test:
+      imports:
+        - glad
+      requires:
+        - pip
+      commands:
+        - pip check
 
   - name: glad2-cmake
     script: install_cmake.sh  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,8 +36,9 @@ outputs:
         - pip check
 
   - name: glad2-cmake
-    script: install_cmake.sh  # [unix]
-    script: install_cmake.bat  # [win]
+    script:
+      - ${RECIPE_DIR}/install_cmake.sh  # [not win]
+      - "%RECIPE_DIR%\\install_cmake.bat"  # [win]
     build:
       skip: false
     requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,8 @@ build:
 outputs:
   - name: glad2
     build:
+      noarch: python
+      skip: true  # [not linux64]
       script: python -m pip install . --no-deps --no-build-isolation -vv
       entry_points:
         - glad = glad.__main__:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ outputs:
         - setuptools
         - wheel
       run:
-        - python
+        - python >=3.9
         - jinja2 >=2.7,<4.0
     test:
       imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,6 @@ outputs:
   - name: glad2
     build:
       noarch: python
-      skip: true  # [not linux64]
       script: python -m pip install . --no-deps --no-build-isolation -vv
       entry_points:
         - glad = glad.__main__:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,8 +13,8 @@ build:
 
 outputs:
   - name: glad2
-    script: python -m pip install . --no-deps --no-build-isolation -vv
     build:
+      script: python -m pip install . --no-deps --no-build-isolation -vv
       entry_points:
         - glad = glad.__main__:main
     requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,9 +36,8 @@ outputs:
         - pip check
 
   - name: glad2-cmake
-    script:
-      - ${RECIPE_DIR}/install_cmake.sh  # [not win]
-      - "%RECIPE_DIR%\\install_cmake.bat"  # [win]
+    script: ${RECIPE_DIR}/install_cmake.sh     # [not win]
+    script: "%RECIPE_DIR%\\install_cmake.bat"  # [win]
     build:
       skip: false
     requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,52 +14,48 @@ build:
 outputs:
   - name: glad2
     build:
-      noarch: python
-      skip: true  # [not linux64]
       entry_points:
         - glad = glad.__main__:main
-      script: python -m pip install . --no-deps -vv
-
+      script: python -m pip install . --no-deps --no-build-isolation -vv
     requirements:
       host:
         - pip
-        - python >=3.8
+        - python
+        - setuptools
+        - wheel
       run:
-        - python >=3.8
-        - jinja2
-
-    test:
-      imports:
-        - glad
-      commands:
-        - glad --help
+        - python
+        - jinja2 >=2.7,<4.0
 
   - name: glad2-cmake
+    script: install_cmake.sh  # [unix]
+    script: install_cmake.bat  # [win]
     build:
       skip: false
-
     requirements:
       # dummy build env to avoid EnvironmentLocationNotFound on win
-      build:   # [win]
+      build:     # [win]
         - cmake  # [win]
       run:
         - {{ pin_subpackage('glad2', exact=True) }}
-
-    script: install_cmake.sh  # [unix]
-    script: install_cmake.bat  # [win]
-
     test:
       files:
         - CMakeLists.txt
+      imports:
+        - glad
       requires:
         - cmake
         - ninja
+        - pip
       commands:
+        - pip check
+        - glad --help
         - cmake -G Ninja -B b
 
     about:
       home: https://github.com/Dav1dde/glad
       license: MIT
+      license_family: MIT
       license_file: LICENSE
       summary: CMake package for glad2.
       description: |
@@ -71,10 +67,15 @@ outputs:
         and link `glad_gl_core_mx_33` to target
 
 about:
-  home: https://github.com/Dav1dde/glad
+  home: https://glad.dav1d.de/
+  dev_url: https://github.com/Dav1dde/glad
+  doc_url: https://github.com/Dav1dde/glad/wiki
   license: MIT
+  license_family: MIT
   license_file: LICENSE
-  summary: GL/GLES/EGL/GLX/WGL Loader-Generator based on the official specs.
+  summary: Multi-Language Vulkan/GL/GLES/EGL/GLX/WGL Loader-Generator based on the official specs.
+  description: |
+    Multi-Language Vulkan/GL/GLES/EGL/GLX/WGL Loader-Generator based on the official specs.
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,8 +36,8 @@ outputs:
         - pip check
 
   - name: glad2-cmake
-    script: ${RECIPE_DIR}/install_cmake.sh     # [not win]
-    script: "%RECIPE_DIR%\\install_cmake.bat"  # [win]
+    script: install_cmake.sh   # [not win]
+    script: install_cmake.bat  # [win]
     build:
       skip: false
     requirements:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-7109](https://anaconda.atlassian.net/browse/PKG-7109) 
- [Upstream repository]()

### Explanation of changes:

- A new feedstock

### Notes:

- vtk 9.4.1 requires glad2/glad2-cmake https://github.com/AnacondaRecipes/vtk-feedstock/pull/21
- Keep the glad2 output as noarch python to reduce build efforts. Only `vtk` requires it.

[PKG-7109]: https://anaconda.atlassian.net/browse/PKG-7109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ